### PR TITLE
add approval to prevent infinite loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,18 @@ workflows:
         context: aws-deploy
     - test:
         context: aws-deploy
+    - request-release:
+        type: approval
+        filters:
+          branches:
+            only:
+              - master
     - publish:
         context: aws-deploy
         requires:
         - build
         - test
+        - request-release
         filters:
           branches:
             only: master


### PR DESCRIPTION
Adds a manual approval for the release so the snapshot tagging doesn't trigger another release.