### PR TITLE
Add endpoints4s json schemas

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val DisciplineScalatestVersion = "1.0.0"
 val FS2Version = "2.2.2"
 val ScalaTestVersion = "3.1.0"
 
-scalacOptions ++= Seq(
+ThisBuild / scalacOptions ++= Seq(
   "-deprecation",
   "-encoding",
   "UTF-8",
@@ -99,6 +99,16 @@ lazy val postgis = (project in file("postgis"))
   )
   .dependsOn(core)
 
+lazy val geoJsonEndpoints4s = (project in file("geoJsonEndpoints4s"))
+  .settings(commonSettings)
+  .settings(
+    name := "endpoints4s-geojson-schemas",
+    libraryDependencies ++= Seq(
+      "org.endpoints4s" %% "algebra" % "1.1.0"
+    )
+  )
+  .dependsOn(core)
+
 lazy val tests = (project in file("tests"))
   .settings(commonSettings)
   .settings(noPublishSettings)
@@ -120,5 +130,5 @@ lazy val circeGeoJson = (project in file("."))
   .settings(commonSettings)
   .settings(noPublishSettings)
   .settings(name := "circe-geojson")
-  .dependsOn(core, postgis, geoJsonScalaCheck, geoJsonHttp4s, tests)
-  .aggregate(core, postgis, geoJsonScalaCheck, geoJsonHttp4s, tests)
+  .dependsOn(core, postgis, geoJsonScalaCheck, geoJsonHttp4s, geoJsonEndpoints4s, tests)
+  .aggregate(core, postgis, geoJsonScalaCheck, geoJsonHttp4s, geoJsonEndpoints4s, tests)

--- a/geoJsonEndpoints4s/src/main/scala/compstak/geojson/JsonSchemas.scala
+++ b/geoJsonEndpoints4s/src/main/scala/compstak/geojson/JsonSchemas.scala
@@ -1,0 +1,158 @@
+package compstak.geojson
+
+import cats._
+import cats.implicits._
+import endpoints4s.algebra
+import endpoints4s.{Invalid, Valid, Validated}
+import io.circe
+
+import compstak.geojson._
+
+trait JsonSchemas extends algebra.JsonSchemas {
+
+  implicit def jsonSchemaPosition[A: JsonSchema]: JsonSchema[Position[A]] =
+    implicitly[JsonSchema[List[A]]]
+      .xmapPartial {
+        case x :: y :: Nil      => Valid(Pos2(x, y): Position[A])
+        case x :: y :: z :: Nil => Valid(Pos3(x, y, z): Position[A])
+        case _                  => Invalid("Coordinates must be two- or three-dimensional geographic positions")
+      } {
+        case Pos2(x, y)    => x :: y :: Nil
+        case Pos3(x, y, z) => x :: y :: z :: Nil
+      }
+      .withTitle("Position")
+
+  implicit def jsonSchemaPositionSet[A: JsonSchema]: JsonSchema[PositionSet[A]] =
+    implicitly[JsonSchema[List[Position[A]]]]
+      .xmap(PositionSet(_))(_.elements)
+      .withTitle("PositionSet")
+
+  implicit def jsonSchemaBoundingBox[A: JsonSchema]: JsonSchema[BoundingBox[A]] =
+    implicitly[JsonSchema[List[A]]]
+      .xmapPartial {
+        case llbX :: llbY :: llbZ :: urtX :: urtY :: urtZ :: Nil =>
+          Valid(BoundingBox(Pos3(llbX, llbY, llbZ), Pos3(urtX, urtY, urtZ)))
+        case llbX :: llbY :: urtX :: urtY :: Nil =>
+          Valid(BoundingBox(Pos2(llbX, llbY), Pos2(urtX, urtY)))
+        case _ => Invalid("Not a valid bounding box")
+      } { bb =>
+        (bb.llb.z, bb.urt.z).tupled match {
+          case Some((llbZ, urtZ)) => List(bb.llb.x, bb.llb.y, llbZ, bb.urt.x, bb.urt.y, urtZ)
+          case None               => List(bb.llb.x, bb.llb.y, bb.urt.x, bb.urt.y)
+        }
+      }
+      .withTitle("BoundingBox")
+
+  implicit def jsonSchemaLine[A: JsonSchema]: JsonSchema[Line[A]] =
+    implicitly[JsonSchema[PositionSet[A]]]
+      .xmapPartial(x => Validated.fromOption(Line.fromFoldable(x.elements))("A line instance must be non-empty"))(x =>
+        PositionSet(x.list)
+      )
+      .withTitle("Line")
+
+  implicit def jsonSchemaLineSet[A: JsonSchema]: JsonSchema[LineSet[A]] =
+    implicitly[JsonSchema[List[Line[A]]]]
+      .xmap(LineSet(_))(_.elements)
+      .withTitle("LineSet")
+
+  implicit def jsonSchemaLinearRing[A: JsonSchema: Eq]: JsonSchema[LinearRing[A]] =
+    implicitly[JsonSchema[List[Position[A]]]]
+      .xmapPartial(xs => Validated.fromEither(LinearRing.fromFoldable(xs).leftMap(err => err.getMessage :: Nil)))(
+        _.list
+      )
+      .withTitle("LinearRing")
+
+  implicit def jsonSchemaRingSet[A: JsonSchema: Eq]: JsonSchema[RingSet[A]] =
+    implicitly[JsonSchema[List[LinearRing[A]]]]
+      .xmap(RingSet(_))(_.elements)
+      .withTitle("RingSet")
+
+  implicit def jsonSchemaPolygonSet[A: JsonSchema: Eq]: JsonSchema[PolygonSet[A]] =
+    implicitly[JsonSchema[List[RingSet[A]]]]
+      .xmap(PolygonSet(_))(_.elements)
+      .withTitle("PolygonSet")
+
+  implicit def pointTagged[A: JsonSchema]: Tagged[Point[A]] =
+    field[Position[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap { case (pos, bb) => Point(pos, bb) }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.Point.tag)
+      .withTitle("Point")
+
+  implicit def multiPointTagged[A: JsonSchema]: Tagged[MultiPoint[A]] =
+    field[PositionSet[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap { case (poss, bb) => MultiPoint(poss, bb) }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.MultiPoint.tag)
+      .withTitle("MultiPoint")
+
+  implicit def lineStringTagged[A: JsonSchema]: Tagged[LineString[A]] =
+    field[Line[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap { case (pos, bb) => LineString(pos, bb) }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.LineString.tag)
+      .withTitle("LineString")
+
+  implicit def multiLineStringTagged[A: JsonSchema]: Tagged[MultiLineString[A]] =
+    field[LineSet[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap { case (pos, bb) => MultiLineString(pos, bb) }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.MultiLineString.tag)
+      .withTitle("MultiLineString")
+
+  implicit def polygonTagged[A: JsonSchema: Eq]: Tagged[Polygon[A]] =
+    field[RingSet[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap { case (pos, bb) => Polygon(pos, bb) }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.Polygon.tag)
+      .withTitle("Polygon")
+
+  implicit def multiPolygonTagged[A: JsonSchema: Eq]: Tagged[MultiPolygon[A]] =
+    field[PolygonSet[A]]("coordinates")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap {
+        case (pos, bb) =>
+          MultiPolygon(pos, bb)
+      }(p => p.coordinates -> p.bbox)
+      .tagged(GeometryType.MultiPolygon.tag)
+      .withTitle("MultiPolygon")
+
+  implicit def jsonSchemaGeoJsonGeometry[A: JsonSchema: Eq]: JsonSchema[GeoJsonGeometry[A]] =
+    pointTagged[A]
+      .orElseMerge(multiPointTagged[A])
+      .orElseMerge(lineStringTagged[A])
+      .orElseMerge(multiLineStringTagged[A])
+      .orElseMerge(polygonTagged[A])
+      .orElseMerge(multiPolygonTagged[A])
+
+  implicit def jsonSchemaGeometryCollection[A: JsonSchema: Eq]: JsonSchema[GeometryCollection[A]] =
+    field[List[GeoJsonGeometry[A]]]("geometries")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .zip(field("type")(literal(GeoJsonObjectType.GeometryCollection.tag)))
+      .xmap {
+        case (geometries, bbox) =>
+          GeometryCollection(geometries, bbox)
+      }(x => (x.geometries, x.bbox))
+
+  implicit def jsonSchemaFeature[A: JsonSchema: Eq, P: JsonSchema: circe.Encoder]: JsonSchema[Feature[A, P]] =
+    optField[String]("id")
+      .zip(field[GeoJsonGeometry[A]]("geometry"))
+      .zip(field("type")(literal(GeoJsonObjectType.Feature.tag)))
+      .zip(field[P]("properties"))
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .xmap {
+        case (id, geometry, properties, bbox) =>
+          Feature(geometry, properties, id, bbox)
+      }(x => (x.id, x.geometry, x.properties, x.bbox))
+      .withTitle("Feature")
+
+  implicit def jsonSchemaFeatureCollection[A: JsonSchema: Eq, P: JsonSchema: circe.Encoder]
+    : JsonSchema[FeatureCollection[A, P]] =
+    field[String]("type")
+      .zip(optField[BoundingBox[A]]("bbox"))
+      .zip(field[Seq[Feature[A, P]]]("features"))
+      .xmap { case (_, bbox, features) => FeatureCollection(features, bbox) }(fc =>
+        (GeoJsonObjectType.FeatureCollection.tag, fc.bbox, fc.features)
+      )
+      .withTitle("FeatureCollection")
+}

--- a/tests/src/test/scala/compstak/geojson/GeoJsonCirceExampleSlowSpec.scala
+++ b/tests/src/test/scala/compstak/geojson/GeoJsonCirceExampleSlowSpec.scala
@@ -9,10 +9,12 @@ import fs2.io.file.readAll
 import fs2.text._
 import io.circe._
 import org.scalatest._
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should._
 
 import scala.concurrent.ExecutionContext
 
-class GeoJsonCirceExampleSlowSuite extends FlatSpec with Matchers {
+class GeoJsonCirceExampleSlowSuite extends AnyFlatSpec with Matchers {
   implicit val CS: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   type FreeMap = Option[Json]

--- a/tests/src/test/scala/compstak/geojson/GeoJsonCirceExampleSpec.scala
+++ b/tests/src/test/scala/compstak/geojson/GeoJsonCirceExampleSpec.scala
@@ -7,10 +7,12 @@ import cats.implicits._
 import io.circe._
 import io.circe.literal._
 import org.scalatest._
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should._
 
 import scala.concurrent.ExecutionContext
 
-class GeoJsonCirceExampleSuite extends FlatSpec with Matchers {
+class GeoJsonCirceExampleSuite extends AnyFlatSpec with Matchers {
   implicit val CS: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   // todo fix this when we reenable properties

--- a/tests/src/test/scala/compstak/geojson/GeoJsonCodecSuite.scala
+++ b/tests/src/test/scala/compstak/geojson/GeoJsonCodecSuite.scala
@@ -8,10 +8,16 @@ import cats.data.NonEmptyList
 import compstak.geojson.arbitrary._
 import compstak.geojson.implicits.simple._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.Checkers
+import org.scalactic.anyvals.PosZInt
 
-class GeoJsonCodecSuite extends FlatSpec with Checkers {
+class GeoJsonCodecSuite extends AnyFlatSpec with Checkers with Configuration {
+
+  implicit override val generatorDrivenConfig =
+    PropertyCheckConfiguration(sizeRange = PosZInt(20))
+
   it should "make a codec roundtrip" in {
     check((g: GeoJsonGeometry[Int]) => Eq.eqv(g.asJson.as[GeoJsonGeometry[Int]], Right(g)))
   }

--- a/tests/src/test/scala/compstak/geojson/PostGisGeoJsonCodecSuite.scala
+++ b/tests/src/test/scala/compstak/geojson/PostGisGeoJsonCodecSuite.scala
@@ -1,6 +1,6 @@
 package compstak.geojson
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import cats.kernel.Eq
 import cats.implicits._
 import org.scalacheck.{Arbitrary, Gen}
@@ -10,7 +10,7 @@ import compstak.geojson.implicits.simple._
 import compstak.geojson.postgis._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class PostGisGeoJsonCodecSuite extends FlatSpec with ScalaCheckPropertyChecks {
+class PostGisGeoJsonCodecSuite extends AnyFlatSpec with ScalaCheckPropertyChecks {
   it should "make a codec round trip" in {
     // PostGis doesn't have the notion of a bounding box associated with a geometry
     forAll(genGeoJsonGeometryNoBbox) { (g: GeoJsonGeometry[Int]) =>


### PR DESCRIPTION
JsonSchemas for endpoints4s library.

The scalac arguments were not applied without `ThisBuild /` prepended. 
Unit tests are updated because of deprecation warnings for scalatest stuff, which are errors now (because `-Xfatal-warnings` is actually applied now).

Regarding limiting the size of collections to 20 (instead of default 100) added to `GeoJsonCodecSuite`. Sometimes test takes forever to complete. So that test is killed by timeout on CI. The reason is quadratic memory consumption in the worst case. E.g. there can be a FeatureCollection of 100 features, each of which is a MultyPolygon of 100 Polygons each of 100 LineRings each of 100  points each.