### PR TITLE
Set Scala 3 to 3.3.7 (LTS)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.13.17"
-// TODO: scala 3.5 was chosen among others because:
-// TODO: scala 3.6, 3.7 cannot work with endpoints4s
-ThisBuild / crossScalaVersions := Seq("2.13.17", "3.5.2")
+// scala 3.3.7 (LTS) is used to stay binary-compatible with consumers pinned to the LTS line (e.g. property).
+// scala 3.6, 3.7 cannot work with endpoints4s; 3.3.x LTS works and is older than the previously-used 3.5.2.
+ThisBuild / crossScalaVersions := Seq("2.13.17", "3.3.7")
 
 inThisBuild(
   List(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.0-337"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-337"
+ThisBuild / version := "0.1.1-SNAPSHOT"


### PR DESCRIPTION
## What

- Downgrade the Scala 3 cross-build target from `3.5.2` to `3.3.7` (LTS).
- Set the published version to `0.1.0-337` so consumers pinned to the 3.3.x LTS line can resolve it.

## Why

[property](https://github.com/compstak/property) is moving to Scala **3.3.7 (LTS)** (branch `feature/elements-0.18-scala-3.3.7`). A project on 3.3.7 cannot read TASTy produced by 3.5.2, so circe-geojson must build for 3.3.x to be consumable there. 3.3.7 is older than the previously-used 3.5.2 and still works with endpoints4s (the constraint was 3.6/3.7, not 3.3.x).

`0.1.0-337` has been published to CodeArtifact for Scala 3.3.7 so property can resolve it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)